### PR TITLE
fix: no default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ import core from './core';
 // import ranking from './ranking';
 // import realtime from './realtime';
 // import schedule from './schedule';
-import script from './script';
+import * as script from './script';
 // import showcase from './showcase';
 // import stamina from './stamina';
 // import version from './version';


### PR DESCRIPTION
Fixed the following error when building with tsc

```
~/r/gs2-typescript-sdk (master|✚1…) $ yarn tsc
yarn run v1.22.11
$ /Users/aliyome/repos/gs2-typescript-sdk/node_modules/.bin/tsc
src/index.ts:49:8 - error TS1192: Module '"/Users/aliyome/repos/gs2-typescript-sdk/src/script/index"' has no default export.

49 import script from './script';
          ~~~~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```